### PR TITLE
Corrected parsing sensor data to get all values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,105 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+

--- a/Bebop.py
+++ b/Bebop.py
@@ -74,17 +74,19 @@ class Bebop:
         :param data: raw data packet that needs to be parsed
         :param ack: True if this packet needs to be ack'd and False otherwise
         """
-        (sensor_name, sensor_value, sensor_enum, header_tuple) = self.sensor_parser.extract_sensor_values(raw_data)
-        if (sensor_name is not None):
-            self.sensors.update(sensor_name, sensor_value, sensor_enum)
-            #print(self.sensors)
-        else:
-            color_print("data type %d buffer id %d sequence number %d" % (data_type, buffer_id, sequence_number), "WARN")
-            color_print("This sensor is missing (likely because we don't need it)", "WARN")
+        sensor_list = self.sensor_parser.extract_sensor_values(raw_data)
+        if (sensor_list is not None):
+            for sensor in sensor_list:
+                (sensor_name, sensor_value, sensor_enum, header_tuple) = sensor
+                if (sensor_name is not None):
+                    self.sensors.update(sensor_name, sensor_value, sensor_enum)
+                    #print(self.sensors)
+                else:
+                    color_print("data type %d buffer id %d sequence number %d" % (data_type, buffer_id, sequence_number), "WARN")
+                    color_print("This sensor is missing (likely because we don't need it)", "WARN")
 
         if (ack):
             self.drone_connection.ack_packet(buffer_id, sequence_number)
-
 
     def connect(self, num_retries):
         """

--- a/commandsandsensors/DroneSensorParser.py
+++ b/commandsandsensors/DroneSensorParser.py
@@ -29,14 +29,15 @@ class DroneSensorParser:
         """
         Extract the sensor values from the data in the BLE packet
         :param data: BLE packet of sensor data
-        :return: a tuple of (sensor name, sensor value, sensor enum, header_tuple)
+        :return: a list of tuples of (sensor name, sensor value, sensor enum, header_tuple)
         """
+        sensor_list = []
         #print("updating sensors with ")
         try:
             header_tuple = struct.unpack_from("<BBH", data)
         except:
             color_print("Error: tried to parse a bad sensor packet", "ERROR")
-            return (None, None, None, None)
+            return None
 
         #print(header_tuple)
         (names, data_sizes) = self._parse_sensor_tuple(header_tuple)
@@ -46,43 +47,42 @@ class DroneSensorParser:
         if names is not None:
             for idx, name in enumerate(names):
                 data_size = data_sizes[idx]
-
                 try:
                     if (data_size == "u8" or data_size == "enum"):
                         # unsigned 8 bit, single byte
-                        sensor_data = struct.unpack_from("<B", data, offset=4)
+                        sensor_data = struct.unpack_from("<B", data, offset=4*(idx+1))
                         sensor_data = int(sensor_data[0])
                     elif (data_size == "i8"):
                         # signed 8 bit, single byte
-                        sensor_data = struct.unpack_from("<b", data, offset=4)
+                        sensor_data = struct.unpack_from("<b", data, offset=4*(idx+1))
                         sensor_data = int(sensor_data[0])
                     elif (data_size == "u16"):
-                        sensor_data = struct.unpack_from("<H", data, offset=4)
+                        sensor_data = struct.unpack_from("<H", data, offset=4*(idx+1))
                         sensor_data = int(sensor_data[0])
                     elif (data_size == "i16"):
-                        sensor_data = struct.unpack_from("<h", data, offset=4)
+                        sensor_data = struct.unpack_from("<h", data, offset=4*(idx+1))
                         sensor_data = int(sensor_data[0])
                     elif (data_size == "u32"):
-                        sensor_data = struct.unpack_from("<I", data, offset=4)
+                        sensor_data = struct.unpack_from("<I", data, offset=4*(idx+1))
                         sensor_data = int(sensor_data[0])
                     elif (data_size == "i32"):
-                        sensor_data = struct.unpack_from("<i", data, offset=4)
+                        sensor_data = struct.unpack_from("<i", data, offset=4*(idx+1))
                         sensor_data = int(sensor_data[0])
                     elif (data_size == "u64"):
-                        sensor_data = struct.unpack_from("<Q", data, offset=4)
+                        sensor_data = struct.unpack_from("<Q", data, offset=4*(idx+1))
                         sensor_data = int(sensor_data[0])
                     elif (data_size == "i64"):
-                        sensor_data = struct.unpack_from("<q", data, offset=4)
+                        sensor_data = struct.unpack_from("<q", data, offset=4*(idx+1))
                         sensor_data = int(sensor_data[0])
                     elif (data_size == "float"):
-                        sensor_data = struct.unpack_from("<f", data, offset=4)
+                        sensor_data = struct.unpack_from("<f", data, offset=4*(idx+1))
                         sensor_data = float(sensor_data[0])
                     elif (data_size == "double"):
-                        sensor_data = struct.unpack_from("<d", data, offset=4)
+                        sensor_data = struct.unpack_from("<d", data, offset=4*(idx+1))
                         sensor_data = float(sensor_data[0])
                     elif (data_size == "string"):
                         # string
-                        sensor_data = struct.unpack_from("<s", data, offset=4)
+                        sensor_data = struct.unpack_from("<s", data, offset=4*(idx+1))
                         sensor_data = sensor_data[0]
                     else:
                         sensor_data = None
@@ -90,14 +90,17 @@ class DroneSensorParser:
                 except:
                     sensor_data = None
                     color_print("Error parsing data for sensor", "ERROR")
-
+                
+                #print("%s %s %s" % (name,idx,sensor_data))
                 #color_print("updating the sensor!", "NONE")
-
-                return (name, sensor_data, self.sensor_tuple_cache, header_tuple)
+                sensor_list.append([name, sensor_data, self.sensor_tuple_cache, header_tuple])
+                
+            return sensor_list
+        
         else:
             color_print("Error parsing sensor information!", "ERROR")
             #print(header_tuple)
-            return (None, None, None, None)
+            return None
 
 
     def _parse_sensor_tuple(self, sensor_tuple):


### PR DESCRIPTION
Previously parsing the sensor data for a group of similar sensors would only store the first one (e.g. speedX from speedX, speedY and speedZ). Now all values are extracted and stored in dictionary.

Tested both Attitude and Speed sets. Both appear to work, although accuracy of values is unknown.

Also added .gitignore file.

Tested on Windows7 with Bebop. Untested with Mambo.