### PR TITLE
Hotfix/socket error on disconnect

### DIFF
--- a/Bebop.py
+++ b/Bebop.py
@@ -257,3 +257,52 @@ class Bebop:
 
         return self.drone_connection.send_enum_command_packet_ack(command_tuple, enum_tuple)
 
+    def start_stream(self):
+        """
+        Sends the start stream command to the bebop. The bebop will start streaming
+        RTP packets on the port defined in wifiConnection.py (55004 by default).
+        The packets can be picked up by opening an approriate SDP file in a media
+        player such as VLC, MPlayer, FFMPEG or OpenCV.
+
+        :return: 
+        """
+        
+        command_tuple = self.command_parser.get_command_tuple("ardrone3", "MediaStreaming", "VideoEnable")
+        param_tuple = [1] # Enable
+        param_type_tuple = ['u8']
+        self.drone_connection.send_param_command_packet(command_tuple,param_tuple,param_type_tuple)
+
+
+    def stop_stream(self):
+        """
+        Sends the stop stream command to the bebop. The bebop will stop streaming
+        RTP packets.
+
+        :return: 
+        """
+        
+        command_tuple = self.command_parser.get_command_tuple("ardrone3", "MediaStreaming", "VideoEnable")
+        param_tuple = [0] # Disable
+        param_type_tuple = ['u8']
+        self.drone_connection.send_param_command_packet(command_tuple,param_tuple,param_type_tuple)
+        
+
+    def set_stream_mode(self,mode='low_latency'):
+        """
+        Set the video mode for the RTP stream.
+        :param: mode: one of 'low_latency', 'high_reliability' or 'high_reliability_low_framerate'
+  
+        :return: True if the command was sent and False otherwise
+        """
+        if (mode not in ("low_latency", "high_reliability", "high_reliability_low_framerate")):
+            print("Error: %s is not a valid stream mode.  Must be one of %s" % (mode, "low_latency, high_reliability or high_reliability_low_framerate"))
+            print("Ignoring command and returning")
+            return False
+
+        
+        (command_tuple, enum_tuple) = self.command_parser.get_command_tuple_with_enum("ardrone3",
+                                                                                      "MediaStreaming", "VideoStreamMode", mode)
+        
+        return self.drone_connection.send_enum_command_packet_ack(command_tuple,enum_tuple)
+
+   

--- a/networking/wifiConnection.py
+++ b/networking/wifiConnection.py
@@ -364,6 +364,9 @@ class WifiConnection:
         Disconnect cleanly from the sockets
         """
         self.is_listening = False
+        # Sleep for a moment to allow all socket activity to cease before closing
+        # This avoids a Winsock error regarding a operations on a closed socket 
+        self.smart_sleep(0.5)
         self.udp_send_sock.close()
         self.udp_receive_sock.close()
 

--- a/utils/bebop.sdp
+++ b/utils/bebop.sdp
@@ -1,0 +1,3 @@
+c=IN IP4 192.168.42.1
+m=video 55004 RTP/AVP 96 
+a=rtpmap:96 H264/90000


### PR DESCRIPTION
Occasionally an error would be thrown regarding operation on a closed socket when disconnect() was called. This appears to have been caused by the socket being operated on in a separate thread. Occasionally the socket would be closed before this thread completed. Adding a short delay between initiating the halting of the thread and the closing of the socket fixes this.