### PR TITLE
Add groundcam support

### DIFF
--- a/Mambo.py
+++ b/Mambo.py
@@ -3,6 +3,8 @@ Mambo class holds all of the methods needed to pilot the drone from python and t
 data back from the drone
 
 Author: Amy McGovern, dramymcgovern@gmail.com
+Author: Alexander Zach, https://github.com/alex-zach, groundcam support
+Author: Valentin Benke, https://github.com/Vabe7, groundcam support
 """
 import time
 from networking.wifiConnection import WifiConnection

--- a/examples/demoGroundcam.py
+++ b/examples/demoGroundcam.py
@@ -1,0 +1,31 @@
+'''
+Demo of the groundcam
+Mambo takes off, takes a picture and shows a RANDOM frame, not the last one
+Author: Vabe7, https://github.com/Vabe7
+'''
+from Mambo import Mambo
+import cv2
+import time
+
+mambo = Mambo(None, use_wifi=True) #address is None since it only works with WiFi anyway
+print("trying to connect to mambo now")
+success = mambo.connect(num_retries=3)
+print("connected: %s" % success)
+
+if (success):
+    # get the state information
+    print("sleeping")
+    mambo.smart_sleep(1)
+    mambo.ask_for_state_update()
+    mambo.smart_sleep(1)
+    mambo.safe_takeoff(5)
+    mambo.take_picture()
+    list = mambo.groundcam.get_groundcam_pictures_names() #get list of availible files
+    frame = mambo.groundcam.get_groundcam_picture(list[0],True) #get frame which is the first in the array
+    if frame is not None:
+        if frame is not False:
+            cv2.imshow("Groundcam", frame)
+            cv2.waitKey(100)
+
+    mambo.safe_land(5)
+    mambo.disconnect()

--- a/examples/demoMamboGroundcam.py
+++ b/examples/demoMamboGroundcam.py
@@ -1,7 +1,7 @@
 '''
 Demo of the groundcam
 Mambo takes off, takes a picture and shows a RANDOM frame, not the last one
-Author: Vabe7, https://github.com/Vabe7
+Author: Valentin Benke, https://github.com/Vabe7
 '''
 from Mambo import Mambo
 import cv2


### PR DESCRIPTION
Adds a groundcam class to Mambo.py and an example.
take_picture deletes everything after 35 pictures since it seems like the maximum capacity is 40.