### PR TITLE
Added support for Bebop (v1) drone.

### DIFF
--- a/pyparrot/Bebop.py
+++ b/pyparrot/Bebop.py
@@ -55,20 +55,20 @@ class BebopSensors:
         str = "Bebop sensors: %s" % self.sensors_dict
         return str
 
-class Bebop:
-    def __init__(self):
+class Bebop():
+    def __init__(self, drone_type="Bebop2"):
         """
         Create a new Bebop object.  Assumes you have connected to the Bebop's wifi
 
         """
-        self.drone_connection = WifiConnection(self, drone_type="Bebop")
+        self.drone_connection = WifiConnection(self, drone_type=drone_type)
 
         # intialize the command parser
         self.command_parser = DroneCommandParser()
 
         # initialize the sensors and the parser
         self.sensors = BebopSensors()
-        self.sensor_parser = DroneSensorParser(drone_type="Bebop")
+        self.sensor_parser = DroneSensorParser(drone_type=drone_type)
 
 
     def update_sensors(self, data_type, buffer_id, sequence_number, raw_data, ack):

--- a/pyparrot/networking/wifiConnection.py
+++ b/pyparrot/networking/wifiConnection.py
@@ -37,14 +37,14 @@ class mDNSListener(object):
 
 class WifiConnection:
 
-    def __init__(self, drone, drone_type="Bebop"):
+    def __init__(self, drone, drone_type="Bebop2"):
         """
-        Can be a connection to a Bebop or a Mambo right now
+        Can be a connection to a Bebop, Bebop2 or a Mambo right now
 
         :param type: type of drone to connect to
         """
         self.is_connected = False
-        if (drone_type not in ("Bebop", "Mambo")):
+        if (drone_type not in ("Bebop", "Bebop2", "Mambo")):
             color_print("Error: only type Bebop and Mambo are currently supported", "ERROR")
             return
 
@@ -56,6 +56,11 @@ class WifiConnection:
         self.is_listening = True  # for the UDP listener
 
         if (drone_type == "Bebop"):
+            self.mdns_address = "_arsdk-0901._udp.local."
+            #Bebop video streaming
+            self.stream_port = 55004
+            self.stream_control_port = 55005
+        elif (drone_type == "Bebop2"):
             self.mdns_address = "_arsdk-090c._udp.local."
             #Bebop video streaming
             self.stream_port = 55004
@@ -294,7 +299,7 @@ class WifiConnection:
         tcp_sock.connect((self.drone_ip, self.connection_info.port))
 
         # send the handshake information
-        if(self.drone_type=="Bebop"):
+        if(self.drone_type in ("Bebop", "Bebop2")):
             # For Bebop add video stream ports to the json request
             json_string = json.dumps({"d2c_port":self.udp_receive_port,
                                       "controller_type":"computer",


### PR DESCRIPTION
To maintain backward compatibility renamed currently supported drone_type to Bebop2
and defaulted drone_type to "Bebop2" so all samples still work as they were.
Tested with Bebop (v1) drone demoBebopIndoors.py  was able to discover, start video stream and see in in VLC