### PR TITLE
Fixed wifi connection issue for newer versions of zeroconf

### DIFF
--- a/pyparrot/networking/wifiConnection.py
+++ b/pyparrot/networking/wifiConnection.py
@@ -315,7 +315,7 @@ class WifiConnection:
             tcp_sock.connect(("192.168.99.3", 44444))
         else:
             if (self.ip_address is None):
-                self.drone_ip = ipaddress.IPv4Address(self.connection_info.address).exploded
+                self.drone_ip = ipaddress.IPv4Address(self.connection_info.addresses[0]).exploded
                 tcp_sock.connect((self.drone_ip, self.connection_info.port))
             else:
                 self.drone_ip = ipaddress.IPv4Address(self.ip_address).exploded


### PR DESCRIPTION
Connecting with the bebop 2 drone causes issues due to the changed api of zeroconf. There's no longer the field address. It's now called addresses and contains a list of addresses, whereby the first one is the one needed when connecting to the drone